### PR TITLE
Unpin script

### DIFF
--- a/Pinata/UnpinScript/ReadMe.md
+++ b/Pinata/UnpinScript/ReadMe.md
@@ -1,0 +1,25 @@
+# JS script to unpin all files from pinata ipfs
+
+Added a JS script file (unpin.js) that can be used to unpin all the files from Pinata IPFS using a function where the user needs to pass on their Pinata API Key and Pinata API secret Key.
+
+## How this is built
+
+- To interact with Pinata API through JavaScript, axios npm library is being used
+- The function **userPinList** fetches all the records for the content currently pinned by passing the pinataApiKey and pinataSecretApiKey, stores the ipfs_pin_hash for each pinned file
+in a list (pinnedFiles) and calls the function **unPinFiles** to unpin all the files.
+- In the function **removePinFromIPFS**, we pass in the pin we wish to remove from Pinata and set it as the value for the "hashToUnpin" key in our request URL. This function is used to unpin a single file.
+- The function **unPinFiles** iterates overs the list of the CID's of pinned files and unpins each file using removePinFromIPFS function.
+
+## Tech Stack Used
+
+- JavaScript
+- axios npm library
+
+## Steps to Run
+
+Just call the function **userPinList** from the script by passing the user's pinataApiKey and pinataSecretApiKey as arguments.
+
+## Output Screenshots(Required)
+
+![image](https://user-images.githubusercontent.com/64766655/154789739-3dec7719-aa86-4bd1-b3d1-f9ffe9ca6f8c.png)
+

--- a/Pinata/UnpinScript/unpin.js
+++ b/Pinata/UnpinScript/unpin.js
@@ -1,0 +1,53 @@
+const axios = require('axios');
+var pinnedFiles = [];
+
+// function to unpin a single file with provided hash
+const removePinFromIPFS = (pinataApiKey, pinataSecretApiKey, hashToUnpin) => {
+    const url = `https://api.pinata.cloud/pinning/unpin/${hashToUnpin}`;
+    return axios
+        .delete(url, {
+            headers: {
+                pinata_api_key: pinataApiKey,
+                pinata_secret_api_key: pinataSecretApiKey
+            }
+        })
+        .then(function (response) {
+            console.log("Unpinned Successfully!")
+        })
+        .catch(function (error) {
+            console.log(error);
+        });
+};
+
+// Iterating through all the pins and unpinning them
+const unPinFiles = (pinataApiKey, pinataSecretApiKey, pinnedFiles) => {
+    for(var i=0; i<pinnedFiles.length; i++){
+        removePinFromIPFS(pinataApiKey, pinataSecretApiKey , pinnedFiles[i]);
+    }
+    return;
+}
+
+// getting a list of pinned files and unpinning them
+const userPinList = (pinataApiKey, pinataSecretApiKey) => {
+    
+    const url = `https://api.pinata.cloud/data/pinList?status=pinned`;
+    return axios
+        .get(url, {
+            headers: {
+                pinata_api_key: pinataApiKey,
+                pinata_secret_api_key: pinataSecretApiKey
+            }
+        })
+        .then(function (response) {
+            for(var i=0; i<response.data["count"] ; i++){
+                pinnedFiles.push(response.data["rows"][i]["ipfs_pin_hash"]);
+            }
+            console.log(pinnedFiles);
+            unPinFiles(pinataApiKey, pinataSecretApiKey, pinnedFiles);
+        })
+        .catch(function (error) {
+            console.log(error)
+        });
+};
+
+// execute: userPinList(Your_Pinata_API_Key, Your_Pinata_Secret_API_Key);


### PR DESCRIPTION
# Description

Added a JS script file (unpin.js) that can be used to unpin all the files from Pinata IPFS using a function where the user needs to pass on their Pinata API Key and Pinata API secret Key.

Fixes #25 

## What features have been added or changed/Fixed(In Points)(Required)
- A JS script file was added that unpins all the files from Pinata IPFS by passing **pinataApiKey** and **pinataSecretApiKey** to the **unPinList** function

## Blockchain this work is compatible with(Required)

Ethereum

## Type of change(Required)

- [x] New feature (non-breaking change which adds functionality)

# Checklist(Required):

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Output Screenshots(Required)

![image](https://user-images.githubusercontent.com/64766655/154790111-998799cc-0d3a-4ec6-9e9d-422faa0bb466.png)


